### PR TITLE
Switched JPEG2000 encoder to J2K codestream and extract only RGB from OpenSlideImage

### DIFF
--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -90,6 +90,7 @@ class Jpeg2000Encoder(Encoder):
     def encode(self, data: np.ndarray) -> bytes:
         return jpeg2k_encode(
             data,
+            codecformat="J2K",
             level=self._quality
         )
 

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -379,7 +379,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         """
         if z not in self.focal_planes or path not in self.optical_paths:
             raise ValueError
-        return self._encode(self._get_tile(tile))
+        return self._encode(self._get_tile(tile, flip=True)[:, :, :3])
 
     def _get_decoded_tile(
         self,


### PR DESCRIPTION
This is a fix that switches the JPEG2000 encoder to J2K and extracts RGB from the RGBA OpenSlide image. I checked whether it was possible to specify the colorspace to the OpenJPEG Encoder, but they use the same colorspace enum for RGB and RGBA/ARGB, the nr of components determines the end result. This should resolve #10 and resolve #11 