### PR TITLE
Fixes for openslide

### DIFF
--- a/tests/convert_test_functions.py
+++ b/tests/convert_test_functions.py
@@ -132,7 +132,6 @@ class ConvertTestBase:
                 level_size = (
                     wsi.levels[0].size // pow(2, region['level'])
                 ).to_tuple()
-
                 # Only run test if level is in open slide wsi
                 if level_size in open_wsi.level_dimensions:
                     im = wsi.read_region(
@@ -149,16 +148,20 @@ class ConvertTestBase:
                         index,
                         (region["size"]["width"], region["size"]["height"])
                     )
-                    background = Image.new('RGBA', open_im.size, '#ffffff')
-                    open_im = Image.alpha_composite(background, open_im)
-                    open_im = open_im.convert('RGB')
+                    no_alpha = Image.new(
+                        'RGB',
+                        open_im.size,
+                        (255, 255, 255)
+                    )
+                    no_alpha.paste(open_im, mask=open_im.split()[3])
+                    open_im = no_alpha
 
                     blur = ImageFilter.GaussianBlur(2)
                     diff = ImageChops.difference(
                         im.filter(blur),
                         open_im.filter(blur)
                     )
-
+                    print(scaled_location_x, scaled_location_y, index)
                     for band_rms in ImageStat.Stat(diff).rms:
                         self.assertLess(band_rms, 2, region)  # type: ignore
 

--- a/tests/convert_test_functions.py
+++ b/tests/convert_test_functions.py
@@ -23,7 +23,6 @@ from typing import Dict, Optional, Tuple, Sequence
 from PIL import Image, ImageChops, ImageFilter, ImageStat
 from wsidicom import WsiDicom
 from wsidicomizer.interface import WsiDicomizer
-from wsidicomizer.dataset import create_default_modules
 
 os.add_dll_directory(os.environ['OPENSLIDE'])  # NOQA
 from openslide import OpenSlide

--- a/tests/test_convert_mirax.py
+++ b/tests/test_convert_mirax.py
@@ -12,10 +12,16 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import io
 import os
-
-import pytest
 import unittest
+
+import numpy as np
+import pytest
+from PIL import Image
+from wsidicom.geometry import Size
+from wsidicomizer.encoding import JpegEncoder
+from wsidicomizer.openslide import OpenSlide, OpenSlideLevelImageData
 
 from .convert_test_functions import ConvertTestBase
 
@@ -28,7 +34,52 @@ class MiraxConvertTest(ConvertTestBase, unittest.TestCase):
     )
     input_filename = 'input.mrxs'
     include_levels = [4, 6]
-    tile_size = 1024
+    tile_size: int = 1024
 
     def __init__(self, *args, **kwargs):
         super(ConvertTestBase, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        openslide_path = list(cls.test_folders.keys())[0]
+        cls.openslide = OpenSlide(str(openslide_path)+'/'+cls.input_filename)
+        cls.openslide_imagedata = OpenSlideLevelImageData(
+            cls.openslide,
+            0,
+            512,
+            JpegEncoder()
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.openslide.close()
+
+    def test_detect_blank_tile(self):
+        data = np.full((3, 3, 4), 0)
+        self.assertTrue(self.openslide_imagedata._detect_blank_tile(data))
+
+        data = np.full((3, 3, 4), (50, 50, 50, 0))
+        self.assertTrue(self.openslide_imagedata._detect_blank_tile(data))
+
+        data = np.full((3, 3, 4), (50, 50, 50, 255))
+        self.assertFalse(self.openslide_imagedata._detect_blank_tile(data))
+
+        data = np.full((3, 3, 4), (255, 255, 255, 255))
+        self.assertTrue(self.openslide_imagedata._detect_blank_tile(data))
+
+    def test_create_blank_encoded_frame(self):
+        size = Size(self.tile_size, self.tile_size)
+        frame = self.openslide_imagedata._get_blank_encoded_frame(size)
+        image = Image.open(io.BytesIO(frame))
+        self.assertEqual(image.size, size.to_tuple())
+        data = np.asarray(image)
+        self.assertTrue(np.all(data == self.openslide_imagedata.blank_color))
+
+    def test_create_blank_decoded_frame(self):
+        size = Size(self.tile_size, self.tile_size)
+        image = self.openslide_imagedata._get_blank_decoded_frame(size)
+        self.assertEqual(image.size, size.to_tuple())
+        data = np.asarray(image)
+        self.assertTrue(np.all(data == self.openslide_imagedata.blank_color))

--- a/tests/test_import_czi.py
+++ b/tests/test_import_czi.py
@@ -24,7 +24,6 @@ from typing import Dict, Tuple
 import pytest
 from wsidicom import WsiDicom
 from wsidicomizer.czi import CziDicomizer
-from wsidicomizer.dataset import create_default_modules
 
 
 @pytest.mark.import_czi

--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -148,13 +148,16 @@ class MetaImageData(ImageData, metaclass=ABCMeta):
         dataset.ExtendedDepthOfField = 'NO'
         return WsiDataset(dataset)
 
-    def _encode(self, image_data: Union[Image.Image, np.ndarray]) -> bytes:
+    def _encode(
+        self,
+        image_data: np.ndarray
+    ) -> bytes:
         """Return image data encoded in jpeg using set quality and subsample
         options.
 
         Parameters
         ----------
-        Union[Image.Image, np.ndarray]
+        image_data: np.ndarray
             Image data to encode.
 
         Returns

--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from typing import Optional, Sequence, Union
 
 import numpy as np
+from PIL import Image
 from pydicom import Dataset, config
 from pydicom.dataset import Dataset
 from pydicom.sequence import Sequence as DicomSequence
@@ -147,14 +148,14 @@ class MetaImageData(ImageData, metaclass=ABCMeta):
         dataset.ExtendedDepthOfField = 'NO'
         return WsiDataset(dataset)
 
-    def _encode(self, image_data: np.ndarray) -> bytes:
+    def _encode(self, image_data: Union[Image.Image, np.ndarray]) -> bytes:
         """Return image data encoded in jpeg using set quality and subsample
         options.
 
         Parameters
         ----------
-        image_data: np.ndarray
-            Image data to encode, in RGB-pixel format.
+        Union[Image.Image, np.ndarray]
+            Image data to encode.
 
         Returns
         ----------

--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -154,7 +154,7 @@ class MetaImageData(ImageData, metaclass=ABCMeta):
         Parameters
         ----------
         image_data: np.ndarray
-            Image data to encode, in BGRA-pixel format.
+            Image data to encode, in RGB-pixel format.
 
         Returns
         ----------

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -98,7 +98,6 @@ class JpegEncoder(Encoder):
         """
         if data.dtype != np.dtype(np.uint8):
             data = (data * 255 / np.iinfo(data.dtype).max).astype(np.uint8)
-        print(data.shape)
         return jpeg8_encode(
             data,
             level=self._quality,

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -104,14 +104,15 @@ class JpegEncoder(Encoder):
 class Jpeg2000Encoder(Encoder):
     def __init__(
         self,
-        quality: float = 20
+        quality: float = 20.0
     ) -> None:
         """Creates a JPEG2000 encoder with specified settings.
 
         Parameters
         ----------
-        quality: float = 20. Use < 1 for lossless.
-            The encoding quality.
+        quality: float = 20.0.
+            The encoding quality as peak signal to noise (PSNR). Use < 1 for
+            lossless quality. Up to 60 gives acceptable results.
 
         """
         self._quality = quality

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -43,7 +43,7 @@ class Encoder(metaclass=ABCMeta):
 
 class JpegEncoder(Encoder):
     """Encoder for JPEG."""
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGR']
+    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGRA']
 
     def __init__(
         self,
@@ -67,8 +67,8 @@ class JpegEncoder(Encoder):
         self._subsampling = subsampling
         if input_colorspace not in self.SUPPORTED_COLORSPACES:
             raise NotImplementedError('Non-implemeted colorspace    ')
-        if input_colorspace == 'BGR':
-            self._input_colorspace = 9
+        if input_colorspace == 'BGRA':
+            self._input_colorspace = 13  # CS_EXT_BGRA
         else:
             self._input_colorspace = input_colorspace
         self._outcolorspace = 'YCBCR'
@@ -108,7 +108,7 @@ class JpegEncoder(Encoder):
 
 
 class Jpeg2000Encoder(Encoder):
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGR']
+    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGRA']
 
     def __init__(
         self,
@@ -157,7 +157,7 @@ class Jpeg2000Encoder(Encoder):
         bytes:
             JPEG2000 bytes.
         """
-        if self._input_colorspace == 'BGR':
+        if self._input_colorspace == 'BGRA':
             data = data[:, :, (2, 1, 0)]
         return jpeg2k_encode(
             data,

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -43,7 +43,7 @@ class Encoder(metaclass=ABCMeta):
 
 class JpegEncoder(Encoder):
     """Encoder for JPEG."""
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGR']
+    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE']
 
     def __init__(
         self,
@@ -66,11 +66,8 @@ class JpegEncoder(Encoder):
         self._quality = quality
         self._subsampling = subsampling
         if input_colorspace not in self.SUPPORTED_COLORSPACES:
-            raise NotImplementedError('Non-implemeted colorspace    ')
-        if input_colorspace == 'BGR':
-            self._input_colorspace = 8
-        else:
-            self._input_colorspace = input_colorspace
+            raise NotImplementedError('Non-implemeted colorspace')
+        self._input_colorspace = input_colorspace
         self._outcolorspace = 'YCBCR'
 
     @property
@@ -108,7 +105,7 @@ class JpegEncoder(Encoder):
 
 
 class Jpeg2000Encoder(Encoder):
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE', 'BGR']
+    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE']
 
     def __init__(
         self,
@@ -157,8 +154,6 @@ class Jpeg2000Encoder(Encoder):
         bytes:
             JPEG2000 bytes.
         """
-        if self._input_colorspace == 'BGR':
-            data = data[:, :, (2, 1, 0)]
         return jpeg2k_encode(
             data,
             level=self._quality,

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -12,12 +12,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import io
 from abc import ABCMeta, abstractmethod
-from typing import Union, Optional
+from typing import Optional, Union
 
 import numpy as np
-from imagecodecs import jpeg2k_encode, jpeg8_encode
-from pydicom.uid import UID, JPEGBaseline8Bit, JPEG2000Lossless, JPEG2000
+from PIL import Image
+from pydicom.uid import JPEG2000, UID, JPEG2000Lossless, JPEGBaseline8Bit
 
 
 class Encoder(metaclass=ABCMeta):
@@ -36,20 +37,18 @@ class Encoder(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def encode(self, data: np.ndarray) -> bytes:
+    def encode(self, data: Union[Image.Image, np.ndarray]) -> bytes:
         """Should return data as encoded bytes."""
         raise NotImplementedError
 
 
 class JpegEncoder(Encoder):
     """Encoder for JPEG."""
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE']
 
     def __init__(
         self,
         quality: int = 90,
-        subsampling: Optional[str] = '422',
-        input_colorspace: str = 'RGB'
+        subsampling: Optional[str] = '422'
     ) -> None:
         """Creates a JPEG encoder with specified settings.
 
@@ -59,15 +58,17 @@ class JpegEncoder(Encoder):
             The encoding quality. To not use higher than 95.
         subsampling: Optional[str] = '422'
             Subsampling option.
-        input_colorspace: str = 'RGB'
-            Colorspace of input.
 
         """
+        if subsampling == '444':
+            self._subsampling = 0
+        elif subsampling == '422':
+            self._subsampling = 1
+        elif subsampling == '420':
+            self._subsampling = 2
+        else:
+            raise ValueError("Supsampling should be '444', '422', or '420'")
         self._quality = quality
-        self._subsampling = subsampling
-        if input_colorspace not in self.SUPPORTED_COLORSPACES:
-            raise NotImplementedError('Non-implemeted colorspace')
-        self._input_colorspace = input_colorspace
         self._outcolorspace = 'YCBCR'
 
     @property
@@ -80,37 +81,37 @@ class JpegEncoder(Encoder):
         """Quality setting of encoder"""
         return self._quality
 
-    def encode(self, data: np.ndarray) -> bytes:
-        """Encodes data as JPEG. Converts data to uint8 before conversion.
+    def encode(self, data: Union[Image.Image, np.ndarray]) -> bytes:
+        """Encodes data as JPEG.
 
         Parameters
         ----------
-        data: np.ndarray
-            Numpy array of data to encode.
+        data: Union[Image.Image, np.ndarray
+            Data to encode.
 
         Returns
         ----------
         bytes:
             JPEG bytes.
         """
-        if data.dtype != np.dtype(np.uint8):
-            data = (data * 255 / np.iinfo(data.dtype).max).astype(np.uint8)
-        return jpeg8_encode(
-            data,
-            level=self._quality,
-            colorspace=self._input_colorspace,
-            outcolorspace=self._outcolorspace,
-            subsampling=self._subsampling
-        )
+        if isinstance(data, np.ndarray):
+            data = Image.fromarray(data)
+        with io.BytesIO() as buffer:
+            data.save(
+                buffer,
+                format='JPEG',
+                quality=self.quality,
+                subsampling=self._subsampling
+            )
+            return buffer.getvalue()
 
 
 class Jpeg2000Encoder(Encoder):
-    SUPPORTED_COLORSPACES = ['RGB', 'GRAYSCALE']
+    START_TAGS = bytes([0xFF, 0x4F, 0xFF, 0x51])
 
     def __init__(
         self,
-        quality: float = 2,
-        input_colorspace: str = 'RGB'
+        quality: float = 2
     ) -> None:
         """Creates a JPEG2000 encoder with specified settings.
 
@@ -118,8 +119,7 @@ class Jpeg2000Encoder(Encoder):
         ----------
         quality: float = 2. Use < 1 for lossless.
             The encoding quality.
-        input_colorspace: str = 'RGB'
-            Colorspace of input.
+
 
         """
         self._quality = quality
@@ -127,9 +127,6 @@ class Jpeg2000Encoder(Encoder):
             self._transfer_syntax = JPEG2000Lossless
         else:
             self._transfer_syntax = JPEG2000
-        if input_colorspace not in self.SUPPORTED_COLORSPACES:
-            raise NotImplementedError('Non-implemeted colorspace')
-        self._input_colorspace = input_colorspace
 
     @property
     def transfer_syntax(self) -> UID:
@@ -141,31 +138,36 @@ class Jpeg2000Encoder(Encoder):
         """Quality setting of encoder"""
         return self._quality
 
-    def encode(self, data: np.ndarray) -> bytes:
+    def encode(self, data: Union[Image.Image, np.ndarray]) -> bytes:
         """Encodes data as JPEG2000.
 
         Parameters
         ----------
-        data: np.ndarray
-            Numpy array of data to encode.
+        data: Union[Image.Image, np.ndarray
+            Data to encode.
 
         Returns
         ----------
         bytes:
             JPEG2000 bytes.
         """
-        return jpeg2k_encode(
-            data,
-            level=self._quality,
-            codecformat='J2K',
-        )
+        if isinstance(data, np.ndarray):
+            data = Image.fromarray(data)
+        with io.BytesIO() as buffer:
+            data.save(
+                buffer,
+                format='JPEG2000',
+                quality=self.quality
+            )
+            frame = buffer.getvalue()
+        start_index = frame.find(self.START_TAGS)
+        return frame[start_index:]
 
 
 def create_encoder(
     format: str,
     quality: float,
-    subsampling: Optional[str] = None,
-    input_colorspace: str = 'RGB'
+    subsampling: Optional[str] = None
 ) -> Encoder:
     """Creates an encoder with specified settings.
 
@@ -177,8 +179,6 @@ def create_encoder(
         The encoding quality.
     subsampling: Optional[str] = None
         Subsampling setting (for jpeg).
-    input_colorspace: str = 'RGB'
-        Colorspace of input.
     Returns
     ----------
     Enocer
@@ -187,12 +187,10 @@ def create_encoder(
     if format == 'jpeg':
         return JpegEncoder(
             quality=int(quality),
-            subsampling=subsampling,
-            input_colorspace=input_colorspace
+            subsampling=subsampling
         )
     elif format == 'jpeg2000':
         return Jpeg2000Encoder(
-            quality=quality,
-            input_colorspace=input_colorspace
+            quality=quality
         )
     raise ValueError("Encoder format must be 'jpeg' or 'jpeg2000'")

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -160,6 +160,7 @@ class Jpeg2000Encoder(Encoder):
                 quality=self.quality
             )
             frame = buffer.getvalue()
+        # PIL encodes in jp2, find start of j2k and return from there.
         start_index = frame.find(self.START_TAGS)
         return frame[start_index:]
 

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -47,6 +47,12 @@ if os.name == 'nt':  # On windows, add path to openslide to dll path
         os.environ['PATH'] = (
             openslide_dir + os.pathsep + os.environ['PATH']
         )
+"""
+OpenSlideImageData uses private functions from OpenSlide to get image data as
+numpy arrays instead of pillow images. The private function _read_region is
+used to get raw  data from the OpenSlide C API. We consider this safe, as these
+directly map to the Openslide C API and are thus not likely  to change.
+"""
 
 from openslide import OpenSlide
 from openslide._convert import argb2rgba as convert_argb_to_rgba

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -324,7 +324,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
             region.size.height
         )
         tile_data: np.ndarray = np.frombuffer(buffer, dtype=np.uint8)
-        tile_data.shape = (region.size.width, region.size.height, 4)
+        tile_data.shape = (region.size.height, region.size.width, 4)
         tile_data = self._remove_alpha(tile_data)
         tile_data = self._flip(tile_data)
         return Image.fromarray(tile_data)
@@ -359,7 +359,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
             self._tile_size.height
         )
         tile_data: np.ndarray = np.frombuffer(buffer, dtype=np.uint8)
-        tile_data.shape = (self._tile_size.width, self._tile_size.height, 4)
+        tile_data.shape = (self._tile_size.height, self._tile_size.width, 4)
         tile_data = self._remove_alpha(tile_data)
         if flip:
             tile_data = self._flip(tile_data)

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -85,8 +85,8 @@ class OpenSlideImageData(MetaImageData, metaclass=ABCMeta):
     def _remove_alpha(self, image: Image.Image) -> Image.Image:
         """Return image data with applied for white background. Openslide
         returns fully transparent pixels with RGBA-value 0, 0, 0, 0 for
-        'sparse' areas. At the edge to 'sparse' areas there can also be partial
-        transparency.
+        'sparse' areas. At the edge to 'sparse' areas and at (native) tile
+        edges there can also be partial transparency.
 
         Parameters
         ----------

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -278,7 +278,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         """
         if z not in self.focal_planes:
             raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
-        if z not in self.focal_planes:
+        if path not in self.optical_paths:
             raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         image_data = self._get_region(region)
         if image_data is None:
@@ -429,7 +429,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         """
         if z not in self.focal_planes:
             raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
-        if z not in self.focal_planes:
+        if path not in self.optical_paths:
             raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         tile = self._get_region(
             Region(tile_point*self.tile_size, self.tile_size)
@@ -462,7 +462,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         """
         if z not in self.focal_planes:
             raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
-        if z not in self.focal_planes:
+        if path not in self.optical_paths:
             raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         tile = self._get_region(
             Region(tile_point*self.tile_size, self.tile_size)

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -317,7 +317,7 @@ class OpenSlideLevelImageData(OpenSlideImageData):
             if np.all(transparency == 0):
                 return True
         if np.all(data[CORNERS_Y, CORNERS_X, 0:TRANSPARENCY] == background):
-            if np.any(data[:, :, 0:TRANSPARENCY] != background):
+            if np.all(data[:, :, 0:TRANSPARENCY] == background):
                 return True
         return False
 

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -448,7 +448,7 @@ class OpenSlideDicomizer(MetaDicomizer):
             encoding_format,
             encoding_quality,
             subsampling=jpeg_subsampling,
-            input_colorspace='BGR'
+            input_colorspace='BGRA'
         )
         base_dataset = create_base_dataset(modules)
         slide = OpenSlide(filepath)

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -169,7 +169,7 @@ class OpenSlideAssociatedImageData(OpenSlideImageData):
         path: str
     ) -> bytes:
         if tile != Point(0, 0):
-            raise ValueError
+            raise ValueError("Point(0, 0) only valid tile for non-tiled image")
         return self._encoded_image
 
     def _get_decoded_tile(
@@ -179,7 +179,7 @@ class OpenSlideAssociatedImageData(OpenSlideImageData):
         path: str
     ) -> Image.Image:
         if tile != Point(0, 0):
-            raise ValueError
+            raise ValueError("Point(0, 0) only valid tile for non-tiled image")
         return self._decoded_image
 
 
@@ -271,10 +271,10 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         Image.Image
             Stitched image
         """
-        if path not in self.optical_paths:
-            raise WsiDicomNotFoundError(f"Optical path {path}", str(self))
         if z not in self.focal_planes:
-            raise WsiDicomNotFoundError(f"Z {z}", str(self))
+            raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
+        if z not in self.focal_planes:
+            raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         return self._get_region(region.start, region.size)
 
     def _get_region(
@@ -334,8 +334,10 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         bytes
             Tile bytes.
         """
-        if z not in self.focal_planes or path not in self.optical_paths:
-            raise ValueError
+        if z not in self.focal_planes:
+            raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
+        if z not in self.focal_planes:
+            raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         return self._encode(self._get_tile(tile_point))
 
     def _get_decoded_tile(
@@ -360,8 +362,10 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         Image.Image
             Tile as Image.
         """
-        if z not in self.focal_planes or path not in self.optical_paths:
-            raise ValueError
+        if z not in self.focal_planes:
+            raise WsiDicomNotFoundError(f'focal plane {z}', str(self))
+        if z not in self.focal_planes:
+            raise WsiDicomNotFoundError(f'optical path {path}', str(self))
         return self._get_tile(tile_point)
 
 

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -375,8 +375,10 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         """
         if z not in self.focal_planes or path not in self.optical_paths:
             raise ValueError
-        tile = self._get_tile(tile_point)
-        return Image.fromarray(tile)
+        return self._get_region(
+            tile_point*self.tile_size,
+            self.tile_size
+        )
 
 
 class OpenSlideDicomizer(MetaDicomizer):

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -110,9 +110,9 @@ class OpenSlideImageData(MetaImageData, metaclass=ABCMeta):
         image: Image.Image
              Image data in RGB format.
         """
-        background = Image.new('RGB', image.size, self._background)
-        background.paste(image, mask=image.split()[3])
-        return background
+        no_alpha = Image.new('RGB', image.size, self._background)
+        no_alpha.paste(image, mask=image.split()[3])
+        return no_alpha
 
     def close(self) -> None:
         """Close the open slide object, if not already closed."""

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -48,8 +48,8 @@ if os.name == 'nt':  # On windows, add path to openslide to dll path
             openslide_dir + os.pathsep + os.environ['PATH']
         )
 """
-OpenSlideImageData uses private functions from OpenSlide to get image data as
-numpy arrays instead of pillow images. The private function _read_region is
+OpenSlideImageData uses proteted functions from OpenSlide to get image data as
+numpy arrays instead of pillow images. The proteted function _read_region is
 used to get raw  data from the OpenSlide C API. We consider this safe, as these
 directly map to the Openslide C API and are thus not likely  to change.
 """

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -318,7 +318,10 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         np.ndarray
             Numpy array of tile.
         """
-        return np.asarray(self._get_region(tile_point, self.tile_size))
+        return np.asarray(self._get_region(
+            tile_point*self.tile_size,
+            self.tile_size)
+        )
 
     def _get_encoded_tile(
         self,


### PR DESCRIPTION
Various fixes for openslide. Closes #10 #11 

- Set image offset and size based on image boundary if available.
- Detect if data from openslide is for a blank tile, and allow cached blank tiles to be returned.
- Use pillow for removing alpha.
- Always convert to RGB, as this fixes alpha problems at edges nicely and fast.
- Correctly reshape the read data from openslide (np shape is (height, widht))
- Encode jpeg2000 in j2k and not jp2 format.