### PR TITLE
Relax pixelspacing, fix encoding for non-8-bit data and muliple focal planes

### DIFF
--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -188,7 +188,7 @@ class MetaDicomizer(WsiDicom, metaclass=ABCMeta):
         cls,
         filepath: str,
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None,
-        tile_size: Optional[int] = None,
+        tile_size: int = 512,
         include_levels: Optional[Sequence[int]] = None,
         include_label: bool = True,
         include_overview: bool = True,
@@ -206,7 +206,7 @@ class MetaDicomizer(WsiDicom, metaclass=ABCMeta):
             Path to tiff file
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None
             Module datasets to use in files. If none, use default modules.
-        tile_size: Optional[int]
+        tile_size: int = 512
             Tile size to use if not defined by file.
         include_levels: Sequence[int] = None
             Levels to include. If None, include all levels.

--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -34,18 +34,16 @@ config.future_behavior()
 
 
 class MetaImageData(ImageData, metaclass=ABCMeta):
-    _default_z = 0
+    _default_z = None
 
     def __init__(
         self,
         encoder: Encoder
     ):
-        """Wraps a OpenTilePage to ImageData.
+        """Metaclass for Dicomized image data.
 
         Parameters
         ----------
-        tiled_page: OpenTilePage
-            OpenTilePage to wrap.
         encoded: Encoder
             Encoder to use.
         """

--- a/wsidicomizer/czi.py
+++ b/wsidicomizer/czi.py
@@ -69,8 +69,6 @@ def get_text_from_element(
 
 
 class CziImageData(MetaImageData):
-    _default_z = 0
-
     def __init__(
         self,
         filepath: str,

--- a/wsidicomizer/czi.py
+++ b/wsidicomizer/czi.py
@@ -320,7 +320,6 @@ class CziImageData(MetaImageData):
             Tile as Image.
         """
         if (tile, z, path) not in self.tile_directory:
-            print("return blank tile")
             return self.blank_decoded_tile
         return Image.fromarray(self._get_tile(tile, z, path))
 

--- a/wsidicomizer/encoding.py
+++ b/wsidicomizer/encoding.py
@@ -92,7 +92,7 @@ class JpegEncoder(Encoder):
             JPEG bytes.
         """
         if data.dtype != np.dtype(np.uint8):
-            data = (data * 255 / np.iinfo(data.dtype).max).astype(np.uint8)
+            data = (255 * (data / np.iinfo(data.dtype).max)).astype(np.uint8)
         return jpeg8_encode(
             data,
             level=self._quality,

--- a/wsidicomizer/interface.py
+++ b/wsidicomizer/interface.py
@@ -38,7 +38,7 @@ class WsiDicomizer:
     def open(
         filepath: str,
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None,
-        tile_size: Optional[int] = None,
+        tile_size: int = 512,
         include_levels: Optional[Sequence[int]] = None,
         include_label: bool = True,
         include_overview: bool = True,
@@ -55,7 +55,7 @@ class WsiDicomizer:
             Path to file
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None
             Module datasets to use in files. If none, use default modules.
-        tile_size: int
+        tile_size: int = 512
             Tile size to use if not defined by file.
         include_levels: Sequence[int]
             Optional list of levels to include. Include all levels if None.
@@ -108,7 +108,7 @@ class WsiDicomizer:
         filepath: str,
         output_path: Optional[str] = None,
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None,
-        tile_size: Optional[int] = None,
+        tile_size: int = 512,
         uid_generator: Callable[..., UID] = generate_uid,
         include_levels: Optional[Sequence[int]] = None,
         include_label: bool = True,
@@ -131,7 +131,7 @@ class WsiDicomizer:
             Folder path to save files to.
         modules: Optional[Union[Dataset, Sequence[Dataset]]] = None
             Module datasets to use in files. If none, use default modules.
-        tile_size: int
+        tile_size: int = 512
             Tile size to use if not defined by file.
         uid_generator: Callable[..., UID] = generate_uid
              Function that can gernerate unique identifiers.

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -87,6 +87,14 @@ class OpenSlideImageData(MetaImageData, metaclass=ABCMeta):
         """The uid of the transfer syntax of the image."""
         return self._encoder.transfer_syntax
 
+    @property
+    def focal_planes(self) -> List[float]:
+        return [0.0]
+
+    @property
+    def optical_paths(self) -> List[str]:
+        return ['0']
+
     def close(self) -> None:
         """Close the open slide object, if not already closed."""
         try:

--- a/wsidicomizer/opentile.py
+++ b/wsidicomizer/opentile.py
@@ -55,9 +55,12 @@ class OpenTileImageData(MetaImageData):
         self._image_size = Size(*self._tiled_page.image_size.to_tuple())
         self._tile_size = Size(*self._tiled_page.tile_size.to_tuple())
         self._tiled_size = Size(*self._tiled_page.tiled_size.to_tuple())
-        self._pixel_spacing = SizeMm(
-            *self._tiled_page.pixel_spacing.to_tuple()
-        )
+        if self._tiled_page.pixel_spacing is not None:
+            self._pixel_spacing = SizeMm(
+                *self._tiled_page.pixel_spacing.to_tuple()
+            )
+        else:
+            self._pixel_spacing = None
 
     def __str__(self) -> str:
         return f"{type(self).__name__} for page {self._tiled_page}"
@@ -96,7 +99,7 @@ class OpenTileImageData(MetaImageData):
         return self._tile_size
 
     @property
-    def pixel_spacing(self) -> SizeMm:
+    def pixel_spacing(self) -> Optional[SizeMm]:
         """Size of the pixels in mm/pixel."""
         return self._pixel_spacing
 


### PR DESCRIPTION
Do not require pixel spacing to be set for non-pyramidal images.
Fix scaling of non-8 bit data when encoding to jpeg.
Fix so that multiple focal planes are not overridden to [0.0].
Provide default tile size of 512.