### PR TITLE
Openslide mpp

### DIFF
--- a/wsidicomizer/common.py
+++ b/wsidicomizer/common.py
@@ -56,11 +56,6 @@ class MetaImageData(ImageData, metaclass=ABCMeta):
         """Should return pyramid level for image data."""
         raise NotImplementedError()
 
-    @property
-    @abstractmethod
-    def photometric_interpretation(self) -> str:
-        raise NotImplementedError()
-
     def create_instance_dataset(
         self,
         base_dataset: Dataset,

--- a/wsidicomizer/czi.py
+++ b/wsidicomizer/czi.py
@@ -121,7 +121,7 @@ class CziImageData(MetaImageData):
         self._blank_encoded_tile = self._encode(self._create_blank_tile())
         self._pixel_spacing = self._get_pixel_spacing()
         self._focal_planes = sorted(self._focal_plane_mapping)
-        assert(isinstance(self._czi.filtered_subblock_directory, list))
+        assert isinstance(self._czi.filtered_subblock_directory, list)
         self._block_directory = self._czi.filtered_subblock_directory
         self._block_locks: Dict[int, Lock] = defaultdict(Lock)
 
@@ -240,12 +240,12 @@ class CziImageData(MetaImageData):
 
     def _get_size(self, axis: str) -> int:
         index = self._get_axis_index(axis)
-        assert(isinstance(self._czi.shape, tuple))
+        assert isinstance(self._czi.shape, tuple)
         return self._czi.shape[index]
 
     def _get_start(self, axis: str) -> int:
         index = self._get_axis_index(axis)
-        assert(isinstance(self._czi.start, tuple))
+        assert isinstance(self._czi.start, tuple)
         return self._czi.start[index]
 
     def _get_axis_index(self, axis: str) -> int:
@@ -273,7 +273,7 @@ class CziImageData(MetaImageData):
             fill_value = 0
         else:
             fill_value = 1
-        assert(isinstance(self._czi.dtype, np.dtype))
+        assert isinstance(self._czi.dtype, np.dtype)
         return np.full(
             self._size_to_numpy_shape(self.tile_size),
             fill_value * np.iinfo(self._czi.dtype).max,
@@ -343,7 +343,6 @@ class CziImageData(MetaImageData):
 
             # Get decompressed data
             block_data = self._get_tile_data(block.index)
-            # block_data = self._block_reader.get_cached(block.index)
             # Reshape the block data to remove leading 1-indices.
             block_data.shape = self._size_to_numpy_shape(block.size)
             # Paste in block data into tile.
@@ -422,7 +421,7 @@ class CziImageData(MetaImageData):
         tile_directory: Dict[Tuple[Point, float, str], List[CziBlock]] = (
             defaultdict(list)
         )
-        assert(isinstance(self._czi.filtered_subblock_directory, list))
+        assert isinstance(self._czi.filtered_subblock_directory, list)
         for index, block in enumerate(self._czi.filtered_subblock_directory):
             block_start, block_size, z, c = self._get_block_dimensions(block)
             tile_region = Region.from_points(

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -15,7 +15,6 @@
 import ctypes
 import math
 import os
-from abc import ABCMeta
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
 
@@ -62,7 +61,7 @@ from openslide.lowlevel import (_read_region,
                                 get_associated_image_names)
 
 
-class OpenSlideImageData(MetaImageData, metaclass=ABCMeta):
+class OpenSlideImageData(MetaImageData):
     def __init__(
         self,
         open_slide: OpenSlide,
@@ -219,12 +218,18 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         )
         self._pyramid_index = int(math.log2(self.downsample))
 
-        base_mpp_x = float(self._slide.properties['openslide.mpp-x'])
-        base_mpp_y = float(self._slide.properties['openslide.mpp-y'])
-        self._pixel_spacing = SizeMm(
-            base_mpp_x * self.downsample / 1000.0,
-            base_mpp_y * self.downsample / 1000.0
-        )
+        try:
+            base_mpp_x = float(self._slide.properties['openslide.mpp-x'])
+            base_mpp_y = float(self._slide.properties['openslide.mpp-y'])
+            self._pixel_spacing = SizeMm(
+                base_mpp_x * self.downsample / 1000.0,
+                base_mpp_y * self.downsample / 1000.0
+            )
+        except KeyError:
+            raise Exception(
+                "Could not determine pixel spacing as openslide properties "
+                "'openslide.mpp-x' and/or 'openslide.mpp-y' is missing in file"
+            )
 
         # Get set image origin and size to bounds if available
         bounds_x = self._slide.properties.get('openslide.bounds-x', 0)

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -227,8 +227,8 @@ class OpenSlideLevelImageData(OpenSlideImageData):
             )
         except KeyError:
             raise Exception(
-                "Could not determine pixel spacing as openslide properties "
-                "'openslide.mpp-x' and/or 'openslide.mpp-y' is missing in file"
+                "Could not determine pixel spacing as openslide did not "
+                "provide mpp from the file."
             )
 
         # Get set image origin and size to bounds if available


### PR DESCRIPTION
Try-catch when getting mpp from openslide properties and throw informative exception if not found.