### PR TITLE
Openslide background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ...
+### Fixed
+- Handling of OpenSlide images without slide background color.
+
 ## [0.3.1] - 2022-09-09
 ### Fixed
 - Support for openslide-python 1.2.

--- a/wsidicomizer/openslide.py
+++ b/wsidicomizer/openslide.py
@@ -166,9 +166,9 @@ class OpenSlideImageData(MetaImageData):
             RGB color.
 
         """
-        slide_background_color_string = self._slide.properties[
+        slide_background_color_string = self._slide.properties.get(
             PROPERTY_NAME_BACKGROUND_COLOR
-        ]
+        )
         if slide_background_color_string is not None:
             rgb = re.findall(
                 r'([0-9a-fA-F]{2})',


### PR DESCRIPTION
Use get() to get OpenSlide background property to allow for the property to be missing.