### PR TITLE
Relax python requirement, bump wsidicom and opentile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] -
 
+### Changed
+
+- Relaxed python requirement to >= 3.8.
+- Bumped wsidicom and opentil versions.
+
 ## [0.9.3] - 2023-05-17
 
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -271,14 +271,14 @@ files = [
 
 [[package]]
 name = "elementpath"
-version = "4.1.2"
+version = "4.1.4"
 description = "XPath 1.0/2.0/3.0/3.1 parsers and selectors for ElementTree and lxml"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "elementpath-4.1.2-py3-none-any.whl", hash = "sha256:e8a6c5685e1843c620f426c85ad21ff25cfc7554790116b1046adae7dc252458"},
-    {file = "elementpath-4.1.2.tar.gz", hash = "sha256:0bd0ef5bad559b677ba499e9c7342ca1f2ae2bace90808ee52528ec8d9f6e12b"},
+    {file = "elementpath-4.1.4-py3-none-any.whl", hash = "sha256:e7c6d25546dfb381a2c9cde3b78c0c40f52811e06eb810faf019e16c531a74bf"},
+    {file = "elementpath-4.1.4.tar.gz", hash = "sha256:f991c42ff66fa06e219141ccf65890261e6635b448e7d4c2d8b62dc5bf1de9e8"},
 ]
 
 [package.extras]
@@ -358,14 +358,14 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "fsspec"
-version = "2023.5.0"
+version = "2023.6.0"
 description = "File-system specification"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fsspec-2023.5.0-py3-none-any.whl", hash = "sha256:51a4ad01a5bb66fcc58036e288c0d53d3975a0df2a5dc59a93b59bade0391f2a"},
-    {file = "fsspec-2023.5.0.tar.gz", hash = "sha256:b3b56e00fb93ea321bc9e5d9cf6f8522a0198b20eb24e02774d329e9c6fb84ce"},
+    {file = "fsspec-2023.6.0-py3-none-any.whl", hash = "sha256:1cbad1faef3e391fba6dc005ae9b5bdcbf43005c9167ce78c915549c352c869a"},
+    {file = "fsspec-2023.6.0.tar.gz", hash = "sha256:d0b2f935446169753e7a5c5c55681c54ea91996cc67be93c39a154fb3a2742af"},
 ]
 
 [package.extras]
@@ -682,40 +682,40 @@ zfpy = ["zfpy (>=1.0.0)"]
 
 [[package]]
 name = "numpy"
-version = "1.24.3"
+version = "1.24.4"
 description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.24.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c1104d3c036fb81ab923f507536daedc718d0ad5a8707c6061cdfd6d184e570"},
-    {file = "numpy-1.24.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:202de8f38fc4a45a3eea4b63e2f376e5f2dc64ef0fa692838e31a808520efaf7"},
-    {file = "numpy-1.24.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8535303847b89aa6b0f00aa1dc62867b5a32923e4d1681a35b5eef2d9591a463"},
-    {file = "numpy-1.24.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d926b52ba1367f9acb76b0df6ed21f0b16a1ad87c6720a1121674e5cf63e2b6"},
-    {file = "numpy-1.24.3-cp310-cp310-win32.whl", hash = "sha256:f21c442fdd2805e91799fbe044a7b999b8571bb0ab0f7850d0cb9641a687092b"},
-    {file = "numpy-1.24.3-cp310-cp310-win_amd64.whl", hash = "sha256:ab5f23af8c16022663a652d3b25dcdc272ac3f83c3af4c02eb8b824e6b3ab9d7"},
-    {file = "numpy-1.24.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9a7721ec204d3a237225db3e194c25268faf92e19338a35f3a224469cb6039a3"},
-    {file = "numpy-1.24.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d6cc757de514c00b24ae8cf5c876af2a7c3df189028d68c0cb4eaa9cd5afc2bf"},
-    {file = "numpy-1.24.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76e3f4e85fc5d4fd311f6e9b794d0c00e7002ec122be271f2019d63376f1d385"},
-    {file = "numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1d3c026f57ceaad42f8231305d4653d5f05dc6332a730ae5c0bea3513de0950"},
-    {file = "numpy-1.24.3-cp311-cp311-win32.whl", hash = "sha256:c91c4afd8abc3908e00a44b2672718905b8611503f7ff87390cc0ac3423fb096"},
-    {file = "numpy-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:5342cf6aad47943286afa6f1609cad9b4266a05e7f2ec408e2cf7aea7ff69d80"},
-    {file = "numpy-1.24.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7776ea65423ca6a15255ba1872d82d207bd1e09f6d0894ee4a64678dd2204078"},
-    {file = "numpy-1.24.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ae8d0be48d1b6ed82588934aaaa179875e7dc4f3d84da18d7eae6eb3f06c242c"},
-    {file = "numpy-1.24.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecde0f8adef7dfdec993fd54b0f78183051b6580f606111a6d789cd14c61ea0c"},
-    {file = "numpy-1.24.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4749e053a29364d3452c034827102ee100986903263e89884922ef01a0a6fd2f"},
-    {file = "numpy-1.24.3-cp38-cp38-win32.whl", hash = "sha256:d933fabd8f6a319e8530d0de4fcc2e6a61917e0b0c271fded460032db42a0fe4"},
-    {file = "numpy-1.24.3-cp38-cp38-win_amd64.whl", hash = "sha256:56e48aec79ae238f6e4395886b5eaed058abb7231fb3361ddd7bfdf4eed54289"},
-    {file = "numpy-1.24.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4719d5aefb5189f50887773699eaf94e7d1e02bf36c1a9d353d9f46703758ca4"},
-    {file = "numpy-1.24.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ec87a7084caa559c36e0a2309e4ecb1baa03b687201d0a847c8b0ed476a7187"},
-    {file = "numpy-1.24.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea8282b9bcfe2b5e7d491d0bf7f3e2da29700cec05b49e64d6246923329f2b02"},
-    {file = "numpy-1.24.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210461d87fb02a84ef243cac5e814aad2b7f4be953b32cb53327bb49fd77fbb4"},
-    {file = "numpy-1.24.3-cp39-cp39-win32.whl", hash = "sha256:784c6da1a07818491b0ffd63c6bbe5a33deaa0e25a20e1b3ea20cf0e43f8046c"},
-    {file = "numpy-1.24.3-cp39-cp39-win_amd64.whl", hash = "sha256:d5036197ecae68d7f491fcdb4df90082b0d4960ca6599ba2659957aafced7c17"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:352ee00c7f8387b44d19f4cada524586f07379c0d49270f87233983bc5087ca0"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7d6acc2e7524c9955e5c903160aa4ea083736fde7e91276b0e5d98e6332812"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:35400e6a8d102fd07c71ed7dcadd9eb62ee9a6e84ec159bd48c28235bbb0f8e4"},
-    {file = "numpy-1.24.3.tar.gz", hash = "sha256:ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6"},
+    {file = "numpy-1.24.4-cp310-cp310-win32.whl", hash = "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc"},
+    {file = "numpy-1.24.4-cp310-cp310-win_amd64.whl", hash = "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5"},
+    {file = "numpy-1.24.4-cp311-cp311-win32.whl", hash = "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d"},
+    {file = "numpy-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc"},
+    {file = "numpy-1.24.4-cp38-cp38-win32.whl", hash = "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2"},
+    {file = "numpy-1.24.4-cp38-cp38-win_amd64.whl", hash = "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d"},
+    {file = "numpy-1.24.4-cp39-cp39-win32.whl", hash = "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835"},
+    {file = "numpy-1.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2"},
+    {file = "numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"},
 ]
 
 [[package]]
@@ -767,14 +767,14 @@ Pillow = "*"
 
 [[package]]
 name = "opentile"
-version = "0.9.0"
+version = "0.10.0"
 description = "Read tiles from wsi-TIFF files"
 category = "main"
 optional = false
-python-versions = ">=3.8,<3.12"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "opentile-0.9.0-py3-none-any.whl", hash = "sha256:87e312162e5ef3d7b325dc5c792aeb3631be49397d5869f429e1686dffe18c1e"},
-    {file = "opentile-0.9.0.tar.gz", hash = "sha256:61c5a01ec0f31381f5cdb0cc2281e04babcbeb57ac743d58e9961e68d9d16bc5"},
+    {file = "opentile-0.10.0-py3-none-any.whl", hash = "sha256:48ddf57e2c417efac3cdcb24402d8aafeac57a8097c842f5f41e7bfb99784416"},
+    {file = "opentile-0.10.0.tar.gz", hash = "sha256:52cac99c60a3f1fab1958e9e90b88eb80ba2b5b39d496db2afca45a5177b04be"},
 ]
 
 [package.dependencies]
@@ -959,14 +959,14 @@ Pillow = "*"
 
 [[package]]
 name = "pint"
-version = "0.21"
+version = "0.21.1"
 description = "Physical quantities module"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Pint-0.21-py3-none-any.whl", hash = "sha256:998b695e84a34d11702da4a8b9457a39bb5c7ab5ec68db90e948e30878e421f1"},
-    {file = "Pint-0.21.tar.gz", hash = "sha256:3e98bdf01f4dcf840cc0207c0b6f7510d4e0c6288efc1bf470626e875c831172"},
+    {file = "Pint-0.21.1-py3-none-any.whl", hash = "sha256:230ebccc312693117ee925c6492b3631c772ae9f7851a4e86080a15e7be692d8"},
+    {file = "Pint-0.21.1.tar.gz", hash = "sha256:5d5b6b518d0c5a7ab03a776175db500f1ed1523ee75fb7fafe38af8149431c8d"},
 ]
 
 [package.extras]
@@ -981,30 +981,30 @@ xarray = ["xarray"]
 
 [[package]]
 name = "platformdirs"
-version = "3.5.0"
+version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.0-py3-none-any.whl", hash = "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4"},
-    {file = "platformdirs-3.5.0.tar.gz", hash = "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"},
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
-version = "1.0.0"
+version = "1.2.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
 [package.extras]
@@ -1052,48 +1052,48 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.7"
+version = "1.10.9"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d"},
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01aea3a42c13f2602b7ecbbea484a98169fb568ebd9e247593ea05f01b884b2e"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516f1ed9bc2406a0467dd777afc636c7091d71f214d5e413d64fef45174cfc7a"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae150a63564929c675d7f2303008d88426a0add46efd76c3fc797cd71cb1b46f"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af"},
-    {file = "pydantic-1.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:a7cd2251439988b413cb0a985c4ed82b6c6aac382dbaff53ae03c4b23a70e80a"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:68792151e174a4aa9e9fc1b4e653e65a354a2fa0fed169f7b3d09902ad2cb6f1"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe2507b8ef209da71b6fb5f4e597b50c5a34b78d7e857c4f8f3115effaef5fe"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10a86d8c8db68086f1e30a530f7d5f83eb0685e632e411dbbcf2d5c0150e8dcd"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75ae19d2a3dbb146b6f324031c24f8a3f52ff5d6a9f22f0683694b3afcb16fb"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:464855a7ff7f2cc2cf537ecc421291b9132aa9c79aef44e917ad711b4a93163b"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:193924c563fae6ddcb71d3f06fa153866423ac1b793a47936656e806b64e24ca"},
-    {file = "pydantic-1.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d"},
-    {file = "pydantic-1.10.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cc1dde4e50a5fc1336ee0581c1612215bc64ed6d28d2c7c6f25d2fe3e7c3e918"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0cfe895a504c060e5d36b287ee696e2fdad02d89e0d895f83037245218a87fe"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:670bb4683ad1e48b0ecb06f0cfe2178dcf74ff27921cdf1606e527d2617a81ee"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c15582f9055fbc1bfe50266a19771bbbef33dd28c45e78afbe1996fd70966c2a"},
-    {file = "pydantic-1.10.7-cp37-cp37m-win_amd64.whl", hash = "sha256:82dffb306dd20bd5268fd6379bc4bfe75242a9c2b79fec58e1041fbbdb1f7914"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c7f51861d73e8b9ddcb9916ae7ac39fb52761d9ea0df41128e81e2ba42886cd"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6434b49c0b03a51021ade5c4daa7d70c98f7a79e95b551201fff682fc1661245"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d34ab766fa056df49013bb6e79921a0265204c071984e75a09cbceacbbdd5d"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:701daea9ffe9d26f97b52f1d157e0d4121644f0fcf80b443248434958fd03dc3"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf135c46099ff3f919d2150a948ce94b9ce545598ef2c6c7bf55dca98a304b52"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0f85904f73161817b80781cc150f8b906d521fa11e3cdabae19a581c3606209"},
-    {file = "pydantic-1.10.7-cp38-cp38-win_amd64.whl", hash = "sha256:9f6f0fd68d73257ad6685419478c5aece46432f4bdd8d32c7345f1986496171e"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c230c0d8a322276d6e7b88c3f7ce885f9ed16e0910354510e0bae84d54991143"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:976cae77ba6a49d80f461fd8bba183ff7ba79f44aa5cfa82f1346b5626542f8e"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d45fc99d64af9aaf7e308054a0067fdcd87ffe974f2442312372dfa66e1001d"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2a5ebb48958754d386195fe9e9c5106f11275867051bf017a8059410e9abf1f"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:abfb7d4a7cd5cc4e1d1887c43503a7c5dd608eadf8bc615413fc498d3e4645cd"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80b1fab4deb08a8292d15e43a6edccdffa5377a36a4597bb545b93e79c5ff0a5"},
-    {file = "pydantic-1.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e"},
-    {file = "pydantic-1.10.7-py3-none-any.whl", hash = "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6"},
-    {file = "pydantic-1.10.7.tar.gz", hash = "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4"},
+    {file = "pydantic-1.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8"},
+    {file = "pydantic-1.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f"},
+    {file = "pydantic-1.10.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf"},
+    {file = "pydantic-1.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e"},
+    {file = "pydantic-1.10.9-cp38-cp38-win_amd64.whl", hash = "sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4"},
+    {file = "pydantic-1.10.9-cp39-cp39-win_amd64.whl", hash = "sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1"},
+    {file = "pydantic-1.10.9-py3-none-any.whl", hash = "sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305"},
+    {file = "pydantic-1.10.9.tar.gz", hash = "sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be"},
 ]
 
 [package.dependencies]
@@ -1133,14 +1133,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.3.1"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
-    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]
@@ -1152,7 +1152,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-watch"
@@ -1202,14 +1202,14 @@ numpy = "*"
 
 [[package]]
 name = "requests"
-version = "2.30.0"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "requests-2.30.0-py3-none-any.whl", hash = "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294"},
-    {file = "requests-2.30.0.tar.gz", hash = "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
@@ -1323,26 +1323,26 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.5.0"
+version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
+    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "2.0.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
+    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
 ]
 
 [package.extras]
@@ -1393,14 +1393,14 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wsidicom"
-version = "0.9.0"
+version = "0.10.0"
 description = "Tools for handling DICOM based whole scan images"
 category = "main"
 optional = false
-python-versions = ">=3.8,<3.12"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "wsidicom-0.9.0-py3-none-any.whl", hash = "sha256:297bb26f9210b8d5c12545f8098df1d204796c0275d15535265a29e8d1ca8cec"},
-    {file = "wsidicom-0.9.0.tar.gz", hash = "sha256:d007a6862e57bea53d7f7dd5de1b11809d8162879c5a00c2b3f210f234bbd130"},
+    {file = "wsidicom-0.10.0-py3-none-any.whl", hash = "sha256:b17963ba4bbb6bd2114d8021903894c5a00bded4fa26502cc461713da6d01099"},
+    {file = "wsidicom-0.10.0.tar.gz", hash = "sha256:78c3e52b0a1675eb8695bd9f6da3667bfd9397ed60c668d409f70fe36f9c1920"},
 ]
 
 [package.dependencies]
@@ -1411,34 +1411,34 @@ pydicom = ">=2.1.0,<3.0.0"
 
 [[package]]
 name = "xmlschema"
-version = "2.2.3"
+version = "2.3.1"
 description = "An XML Schema validator and decoder"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "xmlschema-2.2.3-py3-none-any.whl", hash = "sha256:7d971045eeeb8de183b56bc7530eb8f3d8276072d08017a962c2c34e93bfdd26"},
-    {file = "xmlschema-2.2.3.tar.gz", hash = "sha256:d21ba86af4432720231fb4b40f1205fa75fd718d6856ec3b8118984de31c225b"},
+    {file = "xmlschema-2.3.1-py3-none-any.whl", hash = "sha256:eac0e10957723689ff0691785da4ffee1e95df3a874e685a179047f7bf07f8fb"},
+    {file = "xmlschema-2.3.1.tar.gz", hash = "sha256:2eb426c5710833a05610c22c8766713a1b87e9405e3eca0b7c658375bf7ec810"},
 ]
 
 [package.dependencies]
-elementpath = ">=4.0.0,<5.0.0"
+elementpath = ">=4.1.2,<5.0.0"
 
 [package.extras]
-codegen = ["elementpath (>=4.0.0,<5.0.0)", "jinja2"]
-dev = ["Sphinx", "coverage", "elementpath (>=4.0.0,<5.0.0)", "flake8", "jinja2", "lxml", "lxml-stubs", "memory-profiler", "mypy", "sphinx-rtd-theme", "tox"]
-docs = ["Sphinx", "elementpath (>=4.0.0,<5.0.0)", "jinja2", "sphinx-rtd-theme"]
+codegen = ["elementpath (>=4.1.2,<5.0.0)", "jinja2"]
+dev = ["Sphinx", "coverage", "elementpath (>=4.1.2,<5.0.0)", "flake8", "jinja2", "lxml", "lxml-stubs", "memory-profiler", "mypy", "sphinx-rtd-theme", "tox"]
+docs = ["Sphinx", "elementpath (>=4.1.2,<5.0.0)", "jinja2", "sphinx-rtd-theme"]
 
 [[package]]
 name = "zarr"
-version = "2.14.2"
+version = "2.15.0"
 description = "An implementation of chunked, compressed, N-dimensional arrays for Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zarr-2.14.2-py3-none-any.whl", hash = "sha256:feb72d6ccc43c447661861020dbf2e685a8367e80d890b6f5905954400394ed2"},
-    {file = "zarr-2.14.2.tar.gz", hash = "sha256:68ec59b8ebdfc4fee5e32bd6c0ce273f72f7d4ed017454b45327c673c60907bc"},
+    {file = "zarr-2.15.0-py3-none-any.whl", hash = "sha256:7296b9f42cdc9096c5349527e71492c1b05ed5464027bfa5d008339796d00b9f"},
+    {file = "zarr-2.15.0.tar.gz", hash = "sha256:3894001c0bb5d68d3d21a0562cc49e6ba14fee7d17ad2be8d088ab301665a4c6"},
 ]
 
 [package.dependencies]
@@ -1456,5 +1456,5 @@ openslide = ["openslide-python"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.12"
-content-hash = "476d9a3ee8a5b69c155b6e0ec398b6db3f2ff8dab87dc5665b5e335045a1a627"
+python-versions = "^3.8"
+content-hash = "640c8aac6a4ccb56bd1deca607afe916c8b9dbebd8aa11e9cfb191b00ad6b5d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-wsidicom = "^0.9.0"
-opentile = "^0.9.0"
+python = "^3.8"
+wsidicom = "^0.10.0"
+opentile = "^0.10.0"
 numpy = "^1.22.0"
-pydicom = "^2.2.1"
+pydicom = ">=2.2.0,<2.4.0"
 highdicom = "^0.20.0"
 czifile = "^2019.7.2"
 imagecodecs = "^2022.9.26"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -238,7 +238,6 @@ class WsiDicomizerConvertTests(unittest.TestCase):
         region: Dict[str, Any],
         lowest_included_level: int,
     ):
-
         with self.open_wsi(file_format, file) as wsi:
             level = region["level"] - lowest_included_level
             converted = wsi.read_region(
@@ -332,24 +331,25 @@ class WsiDicomizerConvertTests(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (file_format, file, file_parameters['image_origin'])
+            (file_format, file, file_parameters["image_coordinate_system"])
             for file_format, format_files in test_parameters.items()
             for file, file_parameters in format_files.items()
         ]
     )
-    def test_image_origin(
+    def test_image_coordinate_system(
         self,
         file_format: str,
         file: str,
-        expected_image_origin: Dict[str, float]
+        expected_image_coordinate_system: Dict[str, float],
     ):
         with self.open_wsi(file_format, file) as wsi:
-            image_origin = wsi.levels[0].default_instance.image_origin
+            image_coordinate_system = wsi.levels[
+                0
+            ].default_instance.image_data.image_coordinate_system
+            assert image_coordinate_system is not None
             self.assertEqual(
-                image_origin.origin.x,
-                expected_image_origin['x']
+                image_coordinate_system.origin.x, expected_image_coordinate_system["x"]
             )
             self.assertEqual(
-                image_origin.origin.y,
-                expected_image_origin['y']
+                image_coordinate_system.origin.y, expected_image_coordinate_system["y"]
             )

--- a/tests/testdata/test_parameters.py
+++ b/tests/testdata/test_parameters.py
@@ -5,143 +5,83 @@ test_parameters = {
             "include_levels": [0, 1, 2],
             "lowest_included_pyramid_level": 0,
             "photometric_interpretation": "RGB",
-            "image_origin": {
-                "x": 25.691574,
-                "y": 23.449873
-            },
+            "image_coordinate_system": {"x": 25.691574, "y": 23.449873},
             "read_region": [
                 {
-                    "location": {
-                        "x": 900,
-                        "y": 1200
-                    },
+                    "location": {"x": 900, "y": 1200},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "ee6fc53c821ed39eb8bb9ea31d6065eb"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "ee6fc53c821ed39eb8bb9ea31d6065eb",
                 },
                 {
-                    "location": {
-                        "x": 450,
-                        "y": 600
-                    },
+                    "location": {"x": 450, "y": 600},
                     "level": 5,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "90d96fafc102df44225b6073e6cd4e3b"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "90d96fafc102df44225b6073e6cd4e3b",
                 },
                 {
-                    "location": {
-                        "x": 225,
-                        "y": 300
-                    },
+                    "location": {"x": 225, "y": 300},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "2225853ad4952b9f1854f9cb97c6736b"
-                }
+                    "size": {"width": 200, "height": 200},
+                    "md5": "2225853ad4952b9f1854f9cb97c6736b",
+                },
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 16400,
-                        "y": 21200
-                    },
+                    "location": {"x": 16400, "y": 21200},
                     "level": 0,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970",
                 }
             ],
             "read_thumbnail": [
                 {
-                    "size": {
-                        "width": 512,
-                        "height": 512
-                    },
-                    "md5": "b27df8f554f6bdd4d4fa42d67eeebe6e"
+                    "size": {"width": 512, "height": 512},
+                    "md5": "b27df8f554f6bdd4d4fa42d67eeebe6e",
                 }
-            ]
+            ],
         },
         "svs1/input.svs": {
             "convert": True,
             "include_levels": [0, 1, 2],
             "lowest_included_pyramid_level": 0,
             "photometric_interpretation": "RGB",
-            "image_origin": {
-                "x": 18.34152,
-                "y": 22.716894
-            },
+            "image_coordinate_system": {"x": 18.34152, "y": 22.716894},
             "read_region": [
                 {
-                    "location": {
-                        "x": 500,
-                        "y": 500
-                    },
+                    "location": {"x": 500, "y": 500},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "b5dae0fce9692bdbb1ab2799d7874402"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "b5dae0fce9692bdbb1ab2799d7874402",
                 },
                 {
-                    "location": {
-                        "x": 0,
-                        "y": 0
-                    },
+                    "location": {"x": 0, "y": 0},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "b08559b881da13a6c0fb218c44244951"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "b08559b881da13a6c0fb218c44244951",
                 },
                 {
-                    "location": {
-                        "x": 100,
-                        "y": 100
-                    },
+                    "location": {"x": 100, "y": 100},
                     "level": 5,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970"
-                }
+                    "size": {"width": 200, "height": 200},
+                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970",
+                },
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 8000,
-                        "y": 8000
-                    },
+                    "location": {"x": 8000, "y": 8000},
                     "level": 0,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "51cc84bd6c1c71a7a7c3e736b3bd3970",
                 },
             ],
             "read_thumbnail": [
                 {
-                    "size": {
-                        "width": 512,
-                        "height": 512
-                    },
-                    "md5": "379210d2aee83bb590aa2a4223707ac1"
+                    "size": {"width": 512, "height": 512},
+                    "md5": "379210d2aee83bb590aa2a4223707ac1",
                 }
-            ]
-        }
+            ],
+        },
     },
     "czi": {
         "czi1/input.czi": {
@@ -150,26 +90,17 @@ test_parameters = {
             "lowest_included_pyramid_level": 0,
             "tile_size": 512,
             "photometric_interpretation": "YBR_FULL_422",
-            "image_origin": {
-                "x": 0.0,
-                "y": 0.0
-            },
+            "image_coordinate_system": {"x": 0.0, "y": 0.0},
             "read_region": [
                 {
-                    "location": {
-                        "x": 30000,
-                        "y": 30000
-                    },
+                    "location": {"x": 30000, "y": 30000},
                     "level": 0,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "aa9e76930398facc8c7910e053a7f418"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "aa9e76930398facc8c7910e053a7f418",
                 }
             ],
             "read_region_openslide": [],
-            "read_thumbnail": []
+            "read_thumbnail": [],
         }
     },
     "mirax": {
@@ -178,13 +109,10 @@ test_parameters = {
             "include_levels": [4, 6],
             "lowest_included_pyramid_level": 4,
             "tile_size": 1024,
-            "encode_format": 'jpeg2000',
+            "encode_format": "jpeg2000",
             "encode_quality": 0,
             "photometric_interpretation": "YBR_RCT",
-            "image_origin": {
-                "x": 2.3061675,
-                "y": 20.79015
-            },
+            "image_coordinate_system": {"x": 2.3061675, "y": 20.79015},
             "read_region": [
                 # OpenSlide produces different results across platforms
                 # {
@@ -214,29 +142,17 @@ test_parameters = {
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 50,
-                        "y": 100
-                    },
+                    "location": {"x": 50, "y": 100},
                     "level": 6,
-                    "size": {
-                        "width": 500,
-                        "height": 500
-                    },
+                    "size": {"width": 500, "height": 500},
                 },
                 {
-                    "location": {
-                        "x": 400,
-                        "y": 500
-                    },
+                    "location": {"x": 400, "y": 500},
                     "level": 4,
-                    "size": {
-                        "width": 500,
-                        "height": 500
-                    },
-                }
+                    "size": {"width": 500, "height": 500},
+                },
             ],
-            "read_thumbnail": []
+            "read_thumbnail": [],
         }
     },
     "ndpi": {
@@ -246,81 +162,45 @@ test_parameters = {
             "lowest_included_pyramid_level": 4,
             "tile_size": 1024,
             "photometric_interpretation": "YBR_FULL_422",
-            "image_origin": {
-                "x": 0.0,
-                "y": 0.0
-            },
+            "image_coordinate_system": {"x": 0.0, "y": 0.0},
             "read_region": [
                 {
-                    "location": {
-                        "x": 940,
-                        "y": 1500
-                    },
+                    "location": {"x": 940, "y": 1500},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "d0c6f57e80b8a05e5617049d1e880425"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "d0c6f57e80b8a05e5617049d1e880425",
                 },
                 {
-                    "location": {
-                        "x": 470,
-                        "y": 750
-                    },
+                    "location": {"x": 470, "y": 750},
                     "level": 5,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "705072936f3171e04d22e82a36340250"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "705072936f3171e04d22e82a36340250",
                 },
                 {
-                    "location": {
-                        "x": 235,
-                        "y": 375
-                    },
+                    "location": {"x": 235, "y": 375},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "29949c1bbf444113b8f07d0ba454b25e"
-                }
+                    "size": {"width": 200, "height": 200},
+                    "md5": "29949c1bbf444113b8f07d0ba454b25e",
+                },
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 940,
-                        "y": 1500
-                    },
+                    "location": {"x": 940, "y": 1500},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
+                    "size": {"width": 200, "height": 200},
                 },
                 {
-                    "location": {
-                        "x": 235,
-                        "y": 375
-                    },
+                    "location": {"x": 235, "y": 375},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                }
+                    "size": {"width": 200, "height": 200},
+                },
             ],
             "read_thumbnail": [
                 {
-                    "size": {
-                        "width": 512,
-                        "height": 512
-                    },
-                    "md5": "ea87500dc544f45c6f600811138dad23"
+                    "size": {"width": 512, "height": 512},
+                    "md5": "ea87500dc544f45c6f600811138dad23",
                 }
-            ]
+            ],
         },
         "ndpi1/input.ndpi": {
             "convert": True,
@@ -328,70 +208,40 @@ test_parameters = {
             "lowest_included_pyramid_level": 4,
             "tile_size": 1024,
             "photometric_interpretation": "YBR_FULL_422",
-            "image_origin": {
-                "x": 0.0,
-                "y": 0.0
-            },
+            "image_coordinate_system": {"x": 0.0, "y": 0.0},
             "read_region": [
                 {
-                    "location": {
-                        "x": 0,
-                        "y": 0
-                    },
+                    "location": {"x": 0, "y": 0},
                     "level": 8,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "3053d9c4e6fe5b77ce1ac72788e1c5ee"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "3053d9c4e6fe5b77ce1ac72788e1c5ee",
                 },
                 {
-                    "location": {
-                        "x": 100,
-                        "y": 100
-                    },
+                    "location": {"x": 100, "y": 100},
                     "level": 8,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "a435e9806ba8a9a8227ebbb99728235c"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "a435e9806ba8a9a8227ebbb99728235c",
                 },
                 {
-                    "location": {
-                        "x": 0,
-                        "y": 0
-                    },
+                    "location": {"x": 0, "y": 0},
                     "level": 6,
-                    "size": {
-                        "width": 500,
-                        "height": 500
-                    },
-                    "md5": "15f166e1facb38aba2eb47f7622c5c3c"
-                }
+                    "size": {"width": 500, "height": 500},
+                    "md5": "15f166e1facb38aba2eb47f7622c5c3c",
+                },
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 0,
-                        "y": 0
-                    },
+                    "location": {"x": 0, "y": 0},
                     "level": 6,
-                    "size": {
-                        "width": 500,
-                        "height": 500
-                    },
+                    "size": {"width": 500, "height": 500},
                 }
             ],
             "read_thumbnail": [
                 {
-                    "size": {
-                        "width": 512,
-                        "height": 512
-                    },
-                    "md5": "995791915459762ac1c251fc8351b4f6"
+                    "size": {"width": 512, "height": 512},
+                    "md5": "995791915459762ac1c251fc8351b4f6",
                 }
-            ]
+            ],
         },
         # "ndpi2/input.ndpi": {
         #     "convert": True,
@@ -399,7 +249,7 @@ test_parameters = {
         #     "lowest_included_pyramid_level": 4,
         #     "tile_size": 1024,
         #     "photometric_interpretation": "YBR_FULL_422",
-        #     "image_origin": {
+        #     "image_coordinate_system": {
         #         "x": 0.0,
         #         "y": 0.0
         #     },
@@ -470,92 +320,50 @@ test_parameters = {
             "include_levels": [4, 5, 6],
             "lowest_included_pyramid_level": 4,
             "photometric_interpretation": "YBR_FULL_422",
-            "image_origin": {
-                "x": 0.0,
-                "y": 0.0
-            },
+            "image_coordinate_system": {"x": 0.0, "y": 0.0},
             "read_region": [
                 {
-                    "location": {
-                        "x": 500,
-                        "y": 1000
-                    },
+                    "location": {"x": 500, "y": 1000},
                     "level": 5,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "38d562c38a21c503dd1da6faff8ac129"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "38d562c38a21c503dd1da6faff8ac129",
                 },
                 {
-                    "location": {
-                        "x": 150,
-                        "y": 300
-                    },
+                    "location": {"x": 150, "y": 300},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "faa48eb511e39271dd222a89ef853c76"
+                    "size": {"width": 200, "height": 200},
+                    "md5": "faa48eb511e39271dd222a89ef853c76",
                 },
                 {
-                    "location": {
-                        "x": 1000,
-                        "y": 2000
-                    },
+                    "location": {"x": 1000, "y": 2000},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                    "md5": "b35b1013f4009ce11f29b82a52444191"
-                }
+                    "size": {"width": 200, "height": 200},
+                    "md5": "b35b1013f4009ce11f29b82a52444191",
+                },
             ],
             "read_region_openslide": [
                 {
-                    "location": {
-                        "x": 500,
-                        "y": 1000
-                    },
+                    "location": {"x": 500, "y": 1000},
                     "level": 5,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
+                    "size": {"width": 200, "height": 200},
                 },
                 {
-                    "location": {
-                        "x": 150,
-                        "y": 300
-                    },
+                    "location": {"x": 150, "y": 300},
                     "level": 6,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
+                    "size": {"width": 200, "height": 200},
                 },
                 {
-                    "location": {
-                        "x": 1000,
-                        "y": 2000
-                    },
+                    "location": {"x": 1000, "y": 2000},
                     "level": 4,
-                    "size": {
-                        "width": 200,
-                        "height": 200
-                    },
-                }
+                    "size": {"width": 200, "height": 200},
+                },
             ],
             "read_thumbnail": [
                 {
-                    "size": {
-                        "width": 512,
-                        "height": 512
-                    },
-                    "md5": "922ab1407d79de6b117bc561625f1a49"
+                    "size": {"width": 512, "height": 512},
+                    "md5": "922ab1407d79de6b117bc561625f1a49",
                 }
-            ]
+            ],
         }
-    }
+    },
 }

--- a/wsidicomizer/extras/openslide/openslide_image_data.py
+++ b/wsidicomizer/extras/openslide/openslide_image_data.py
@@ -25,8 +25,8 @@ from PIL import Image
 from PIL.Image import Image as PILImage
 from pydicom.uid import UID as Uid
 from wsidicom.errors import WsiDicomNotFoundError
-from wsidicom.geometry import Point, PointMm, Region, Size, SizeMm
-from wsidicom.instance import ImageOrigin
+from wsidicom.geometry import Orientation, Point, PointMm, Region, Size, SizeMm
+from wsidicom.instance import ImageCoordinateSystem
 
 from wsidicomizer.encoding import Encoder
 from wsidicomizer.extras.openslide.openslide import (
@@ -244,10 +244,11 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         self._blank_encoded_frame_size = None
         self._blank_decoded_frame = None
         self._blank_decoded_frame_size = None
-        self._image_origin = ImageOrigin(
+        self._image_coordinate_system = ImageCoordinateSystem(
             PointMm(
                 self._offset.x * base_mpp_x / 1000, self._offset.y * base_mpp_y / 1000
-            )
+            ),
+            Orientation((0, 1, 0, 1, 0, 0)),
         )
 
     @property
@@ -276,8 +277,8 @@ class OpenSlideLevelImageData(OpenSlideImageData):
         return self._pyramid_index
 
     @property
-    def image_origin(self) -> ImageOrigin:
-        return self._image_origin
+    def image_coordinate_system(self) -> ImageCoordinateSystem:
+        return self._image_coordinate_system
 
     def stitch_tiles(
         self, region: Region, path: str, z: float, threads: int

--- a/wsidicomizer/image_data.py
+++ b/wsidicomizer/image_data.py
@@ -19,7 +19,8 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 from wsidicom import ImageData
-from wsidicom.instance import ImageOrigin
+from wsidicom.geometry import Orientation, PointMm
+from wsidicom.instance import ImageCoordinateSystem
 
 from wsidicomizer.encoding import Encoder
 
@@ -49,9 +50,9 @@ class DicomizerImageData(ImageData, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @property
-    def image_origin(self) -> ImageOrigin:
-        """Return a default ImageOrigin."""
-        return ImageOrigin()
+    def image_coordinate_system(self) -> ImageCoordinateSystem:
+        """Return a default ImageCoordinateSystem."""
+        return ImageCoordinateSystem(PointMm(0, 0), Orientation((0, 1, 0, 1, 0, 0)))
 
     def _encode(self, image_data: np.ndarray) -> bytes:
         """Return image data encoded in jpeg using set quality and subsample

--- a/wsidicomizer/sources/opentile/opentile_image_data.py
+++ b/wsidicomizer/sources/opentile/opentile_image_data.py
@@ -20,8 +20,8 @@ from opentile.tiff_image import TiffImage
 from PIL import Image
 from pydicom.uid import JPEG2000, UID, JPEG2000Lossless, JPEGBaseline8Bit
 from tifffile.tifffile import COMPRESSION, PHOTOMETRIC
-from wsidicom.geometry import Point, Size, SizeMm, PointMm
-from wsidicom.instance import ImageOrigin
+from wsidicom.geometry import Orientation, Point, PointMm, Size, SizeMm
+from wsidicom.instance import ImageCoordinateSystem
 
 from wsidicomizer.encoding import Encoder
 from wsidicomizer.image_data import DicomizerImageData
@@ -59,11 +59,12 @@ class OpenTileImageData(DicomizerImageData):
         else:
             self._pixel_spacing = None
         if image_offset is not None:
-            self._image_origin = ImageOrigin(
-                origin=PointMm(image_offset[0], image_offset[1])
+            self._image_coordinate_system = ImageCoordinateSystem(
+                origin=PointMm(image_offset[0], image_offset[1]),
+                orientation=Orientation((0, 1, 0, 1, 0, 0)),
             )
         else:
-            self._image_origin = ImageOrigin()
+            self._image_coordinate_system = None
 
     def __str__(self) -> str:
         return f"{type(self).__name__} for page {self._tiff_image}"
@@ -124,8 +125,10 @@ class OpenTileImageData(DicomizerImageData):
         return self._tiff_image.pyramid_index
 
     @property
-    def image_origin(self) -> ImageOrigin:
-        return self._image_origin
+    def image_coordinate_system(self) -> ImageCoordinateSystem:
+        if self._image_coordinate_system is None:
+            return super().image_coordinate_system
+        return self._image_coordinate_system
 
     @property
     def photometric_interpretation(self) -> str:

--- a/wsidicomizer/sources/tiffslide/tiffslide_image_data.py
+++ b/wsidicomizer/sources/tiffslide/tiffslide_image_data.py
@@ -34,8 +34,8 @@ from tiffslide import (
     TiffSlide,
 )
 from wsidicom.errors import WsiDicomNotFoundError
-from wsidicom.geometry import Point, PointMm, Region, Size, SizeMm
-from wsidicom.instance import ImageOrigin
+from wsidicom.geometry import Orientation, Point, PointMm, Region, Size, SizeMm
+from wsidicom.instance import ImageCoordinateSystem
 
 from wsidicomizer.encoding import Encoder
 from wsidicomizer.image_data import DicomizerImageData
@@ -231,10 +231,11 @@ class TiffSlideLevelImageData(TiffSlideImageData):
         self._blank_encoded_frame_size = None
         self._blank_decoded_frame = None
         self._blank_decoded_frame_size = None
-        self._image_origin = ImageOrigin(
+        self._image_coordinate_system = ImageCoordinateSystem(
             PointMm(
                 self._offset.x * base_mpp_x / 1000, self._offset.y * base_mpp_y / 1000
-            )
+            ),
+            Orientation((0, 1, 0, 1, 0, 0)),
         )
 
     @property
@@ -263,8 +264,8 @@ class TiffSlideLevelImageData(TiffSlideImageData):
         return self._pyramid_index
 
     @property
-    def image_origin(self) -> ImageOrigin:
-        return self._image_origin
+    def image_coordinate_system(self) -> ImageCoordinateSystem:
+        return self._image_coordinate_system
 
     def stitch_tiles(
         self, region: Region, path: str, z: float, threads: int


### PR DESCRIPTION
Relax python support to >= 3.8, bump wsidicom to 0.10.0 and opentile to 0.10.0.