### PR TITLE
Fix lossy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Setting of `LossyImageCompression`, `LossyImageCompressionRatio`, and `LossyImageCompressionMethod` when image data requires transcoding.
+- Correct `LossyImageCompressionRatio` for `OpenTileImageData`.
+
 ## [0.16.0] - 2025-01-29
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -1017,13 +1017,13 @@ Pillow = "*"
 
 [[package]]
 name = "opentile"
-version = "0.14.0"
+version = "0.15.0"
 description = "Read tiles from wsi-TIFF files"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "opentile-0.14.0-py3-none-any.whl", hash = "sha256:b205caf2c71d1cc7975f84c07b4919c3f1aa6545970ea311cf35fdaa5e90d6cb"},
-    {file = "opentile-0.14.0.tar.gz", hash = "sha256:fc5f10f7cb5b8e64a2a42c58390781ac55570e2c940c0dc542bcc207a36d4808"},
+    {file = "opentile-0.15.0-py3-none-any.whl", hash = "sha256:419a986f3ce8c1eab0364ccb17329de946bbbba7677d64ae1cadacecf8ea7bed"},
+    {file = "opentile-0.15.0.tar.gz", hash = "sha256:1f98d5c54558b2876d52fc84eb9c368ecbadaf54daa22af4bd4e663f10acdb59"},
 ]
 
 [package.dependencies]
@@ -1729,13 +1729,13 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wsidicom"
-version = "0.23.0"
+version = "0.24.0"
 description = "Tools for handling DICOM based whole scan images"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "wsidicom-0.23.0-py3-none-any.whl", hash = "sha256:e5c3fa9d354f56a653d69a679d4efdbe152dea2d071e71ae24fb38d2d903f66d"},
-    {file = "wsidicom-0.23.0.tar.gz", hash = "sha256:3eb33becb4c82821cb3127e6e92ed933eab8cf0e25c5955ab426febeda5bacd2"},
+    {file = "wsidicom-0.24.0-py3-none-any.whl", hash = "sha256:6a0096cc502997f276aa2da0188ee5dadd4731244622fd1a0b87f91bf27bf548"},
+    {file = "wsidicom-0.24.0.tar.gz", hash = "sha256:4e09cd5fca7d7bba079ee81462424715674b127cfd3bdacfe04290f44df8bc64"},
 ]
 
 [package.dependencies]
@@ -1803,4 +1803,4 @@ openslide = ["openslide-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "785b3a19fed13992780966d3270bba6e00928156dd2584bca085985201d34868"
+content-hash = "efe877febf847a15b3a1c14db1eec5dffb97d68d319115e96de9099dad8a8f97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-wsidicom = "^0.23.0"
-opentile = "^0.14.0"
+wsidicom = "^0.24.0"
+opentile = "^0.15.0"
 numpy = ">=1.22.0"
 pydicom = ">=3.0.0"
 czifile = "^2019.7.2"

--- a/wsidicomizer/image_data.py
+++ b/wsidicomizer/image_data.py
@@ -22,7 +22,7 @@ import numpy as np
 from PIL import Image as Pillow
 from PIL.Image import Image
 from wsidicom import ImageData
-from wsidicom.codec import LossyCompressionIsoStandard
+from wsidicom.codec import Encoder, LossyCompressionIsoStandard
 from wsidicom.geometry import PointMm, Size
 from wsidicom.metadata import ImageCoordinateSystem
 
@@ -56,6 +56,11 @@ class DicomizerImageData(ImageData, metaclass=ABCMeta):
     ) -> Optional[List[Tuple[LossyCompressionIsoStandard, float]]]:
         """Return None as image compression is for most format not known."""
         return None
+
+    @property
+    def transcoder(self) -> Optional[Encoder]:
+        """Return encoder as for most format transcoding is used."""
+        return self.encoder
 
     def _encode(self, image_data: np.ndarray) -> bytes:
         """Return image data encoded in jpeg using set quality and subsample

--- a/wsidicomizer/sources/opentile/opentile_image_data.py
+++ b/wsidicomizer/sources/opentile/opentile_image_data.py
@@ -154,7 +154,7 @@ class OpenTileImageData(DicomizerImageData):
             self.image_size.area * self.samples_per_pixel * self.bits // 8
         )
         compressed_size = self._tiff_image.compressed_size
-        compression_ratio = round(compressed_size / uncompressed_size, 2)
+        compression_ratio = round(uncompressed_size / compressed_size, 2)
         return [(iso, compression_ratio)]
 
     def _get_encoded_tile(self, tile: Point, z: float, path: str) -> bytes:

--- a/wsidicomizer/sources/opentile/opentile_image_data.py
+++ b/wsidicomizer/sources/opentile/opentile_image_data.py
@@ -157,6 +157,13 @@ class OpenTileImageData(DicomizerImageData):
         compression_ratio = round(uncompressed_size / compressed_size, 2)
         return [(iso, compression_ratio)]
 
+    @property
+    def transcoder(self) -> Optional[Encoder]:
+        """Only return encoder if transcoding is used."""
+        if self._needs_transcoding:
+            return self.encoder
+        return None
+
     def _get_encoded_tile(self, tile: Point, z: float, path: str) -> bytes:
         """Return image bytes for tile. Returns transcoded tile if
         non-supported encoding.

--- a/wsidicomizer/wsidicomizer.py
+++ b/wsidicomizer/wsidicomizer.py
@@ -213,6 +213,7 @@ class WsiDicomizer(WsiDicom):
                 include_overviews=include_overview,
                 add_missing_levels=add_missing_levels,
                 label=label,
+                transcoding=encoding,
             )
 
         return [str(filepath) for filepath in created_files]
@@ -236,7 +237,9 @@ class WsiDicomizer(WsiDicom):
         return selected_source
 
     @staticmethod
-    def _select_encoder(encoding: Optional[Union[Encoder, EncodingSettings]] = None):
+    def _select_encoder(
+        encoding: Optional[Union[Encoder, EncodingSettings]] = None
+    ) -> Encoder:
         """Return encoder from encoding."""
         if encoding is None:
             encoding = JpegSettings()

--- a/wsidicomizer/wsidicomizer.py
+++ b/wsidicomizer/wsidicomizer.py
@@ -97,23 +97,8 @@ class WsiDicomizer(WsiDicom):
         """
         if not isinstance(filepath, Path):
             filepath = Path(filepath)
-
-        selected_source = None
-        if preferred_source is None:
-            selected_source = next(
-                (source for source in loaded_sources if source.is_supported(filepath)),
-                None,
-            )
-        elif preferred_source.is_supported(filepath):
-            selected_source = preferred_source
-        if selected_source is None:
-            raise NotImplementedError(f"{filepath} is not supported")
-        if encoding is None:
-            encoding = JpegSettings()
-        if isinstance(encoding, EncodingSettings):
-            encoder = Encoder.create_for_settings(encoding)
-        else:
-            encoder = encoding
+        selected_source = cls._select_source(filepath, preferred_source)
+        encoder = cls._select_encoder(encoding)
 
         source = selected_source(
             filepath,
@@ -231,3 +216,32 @@ class WsiDicomizer(WsiDicom):
             )
 
         return [str(filepath) for filepath in created_files]
+
+    @staticmethod
+    def _select_source(
+        filepath: Path,
+        preferred_source: Optional[Type[DicomizerSource]] = None,
+    ) -> Type[DicomizerSource]:
+        """Return source that supports file in filepath."""
+        selected_source = None
+        if preferred_source is None:
+            selected_source = next(
+                (source for source in loaded_sources if source.is_supported(filepath)),
+                None,
+            )
+        elif preferred_source.is_supported(filepath):
+            selected_source = preferred_source
+        if selected_source is None:
+            raise NotImplementedError(f"{filepath} is not supported")
+        return selected_source
+
+    @staticmethod
+    def _select_encoder(encoding: Optional[Union[Encoder, EncodingSettings]] = None):
+        """Return encoder from encoding."""
+        if encoding is None:
+            encoding = JpegSettings()
+        if isinstance(encoding, EncodingSettings):
+            encoder = Encoder.create_for_settings(encoding)
+        else:
+            encoder = encoding
+        return encoder


### PR DESCRIPTION
- Add property `transcoder` to indicate if image data requires transcoding when reading byte tiles.
- Fix calculation of compression ratio for `OpenTileImageData`.