### PR TITLE
Fix for Unused exception object

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -708,6 +708,7 @@ def convert_wsi(file_path: Path, file_parameters: dict[str, Any], encoder: Encod
     force_transcoding = file_parameters.get("force_transcoding", True)
     tile_size = file_parameters.get("tile_size", DEFAULT_TILE_SIZE)
     tempdir = TemporaryDirectory()
+    os.rmdir(tempdir.name)
     WsiDicomizer.convert(
         file_path,
         output_path=tempdir.name,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -432,16 +432,17 @@ class TestWsiDicomizerConvert:
 
         # Act
         with TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "wsi")
             WsiDicomizer.convert(
                 wsi_file,
-                temp_dir,
+                output_path,
                 include_levels=[-1],
                 label=label,
                 encoding=Jpeg2kTestEncoder(),
             )
 
             # Assert
-            with WsiDicom.open(temp_dir) as wsi:
+            with WsiDicom.open(output_path) as wsi:
                 new_label = wsi.read_label()
 
         assert np.array_equal(np.array(new_label), np.array(label))

--- a/wsidicomizer/metadata.py
+++ b/wsidicomizer/metadata.py
@@ -94,26 +94,6 @@ class WsiDicomizerMetadata(WsiMetadata):
             dimension_organization_uids = user.dimension_organization_uids
         if dimension_organization_uids is None:
             dimension_organization_uids = default.dimension_organization_uids
-        # label = self._merge_module_with_image(
-        #     Label, base.label, user.label, default.label
-        # )
-        #     overview = self._merge_module_with_image(
-        #         Overview, base.overview, user.overview, default.overview
-        #     )
-        # if ensure_label:
-        #     if label is None:
-        #         label = Label(image=Image(), optical_paths=[])
-        #     elif label.image is None:
-        #         label = replace(label, image=Image())
-        #     elif label.optical_paths is None:
-        #         label = replace(label, optical_paths=[])
-        # if ensure_overview:
-        #     if overview is None:
-        #         overview = Overview(image=Image(), optical_paths=[])
-        #     if overview.image is None:
-        #         overview = replace(overview, image=Image())
-        #     elif overview.optical_paths is None:
-        #         overview = replace(overview, optical_paths=[])
         return WsiDicomizerMetadata(
             study=self._merge(Study, base.study, user.study, default.study),
             series=self._merge(Series, base.series, user.series, default.series),

--- a/wsidicomizer/wsidicomizer.py
+++ b/wsidicomizer/wsidicomizer.py
@@ -242,7 +242,7 @@ class WsiDicomizer(WsiDicom):
             try:
                 os.mkdir(output_path)
             except FileExistsError:
-                ValueError(f"Output path {output_path} already exists")
+                raise ValueError(f"Output path {output_path} already exists")
             created_files = wsi.save(
                 output_path,
                 uid_generator,

--- a/wsidicomizer/wsidicomizer.py
+++ b/wsidicomizer/wsidicomizer.py
@@ -242,7 +242,7 @@ class WsiDicomizer(WsiDicom):
             try:
                 os.mkdir(output_path)
             except FileExistsError:
-                raise ValueError(f"Output path {output_path} already exists")
+                raise ValueError(f"Output path {output_path} already exists") from None
             created_files = wsi.save(
                 output_path,
                 uid_generator,


### PR DESCRIPTION
To fix this, raise the created exception instead of just instantiating it.

Best single change (no functional redesign): in `wsidicomizer/wsidicomizer.py`, replace:

- `ValueError(f"Output path {output_path} already exists")`

with:

- `raise ValueError(f"Output path {output_path} already exists")`

This preserves existing logic and message while making the error path effective. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._